### PR TITLE
fix order of mta extensions for extension-descriptor-different-environments example

### DIFF
--- a/extension-descriptor-different-environments/prod-scale-vertically.mtaext
+++ b/extension-descriptor-different-environments/prod-scale-vertically.mtaext
@@ -1,6 +1,6 @@
 _schema-version: 3.3.0
 ID: my-mta-prod-scale-vertically
-extends: my-mta
+extends: my-mta-prod
 version: 1.0.0
 
 modules:


### PR DESCRIPTION
The `extension-descriptor-different-environments` example is currently not working as two extensions `prod.mtaext` and `prod-scale-vertically.mtaext` extend the same ID `my-mta` and hence the order can not be determined.

Running `cf deploy -f -e prod.mtaext,prod-scale-vertically.mtaext` shows the following logs:
```txt
Using extension descriptor with ID: "my-mta-prod"
Provided but unused extension descriptors because extend another MTA ID or extends order is not correct: [my-mta-prod]
Detected MTA schema version: "3"
Detected deployed MTA with ID "my-mta" and version "1.0.0"
Detected new MTA version: "1.0.0"
Deployed MTA version: "1.0.0"
```

Currently:
- my-mta-prod -> my-mta
- my-mta-prod-scale-vertically

This PR contains a fix, which specifies the order of extensions as follows:
- my-mta-prod-scale-vertically -> my-mta-prod -> my-mta

> Hint: The fix is already mentioned in the corresponding [readme](https://github.com/SAP-samples/cf-mta-examples/blob/07fec41fafafdfb424735b3af3a3e077a75665e0/extension-descriptor-different-environments/README.adoc?plain=1#L179) for the example.