### PR TITLE
Add health-check-interval to cf-app example

### DIFF
--- a/cf-app/mta.yaml
+++ b/cf-app/mta.yaml
@@ -30,5 +30,6 @@ modules:
       health-check-type: http #http/port/process
       health-check-http-endpoint: "/index" # the http route pinged
       health-check-timeout: 180 #seconds
+      health-check-interval: 30 #seconds, liveness health check polling interval
       app-features:
         ssh: true

--- a/cf-app/mtad.yaml
+++ b/cf-app/mtad.yaml
@@ -30,5 +30,6 @@ modules:
       health-check-type: http #http/port/process
       health-check-http-endpoint: "/index" # the http route pinged
       health-check-timeout: 180 #seconds
+      health-check-interval: 30 #seconds, liveness health check polling interval
       app-features:
         ssh: true


### PR DESCRIPTION
Demonstrates the new liveness health check interval parameter (health-check-interval: 30) alongside the existing health-check-type, health-check-http-endpoint, and health-check-timeout parameters.

JIRA:LMCROSSITXSADEPLOY-3316