### PR TITLE
Showcase health-check-interval in cf-app example

### DIFF
--- a/cf-app/mta.yaml
+++ b/cf-app/mta.yaml
@@ -30,5 +30,6 @@ modules:
       health-check-type: http #http/port/process
       health-check-http-endpoint: "/index" # the http route pinged
       health-check-timeout: 180 #seconds
+      health-check-interval: 15 #seconds; how often CF runs the liveness check
       app-features:
         ssh: true

--- a/cf-app/mtad.yaml
+++ b/cf-app/mtad.yaml
@@ -30,5 +30,6 @@ modules:
       health-check-type: http #http/port/process
       health-check-http-endpoint: "/index" # the http route pinged
       health-check-timeout: 180 #seconds
+      health-check-interval: 15 #seconds; how often CF runs the liveness check
       app-features:
         ssh: true


### PR DESCRIPTION
## Summary

Adds the module-level MTA parameter `health-check-interval` to the canonical `cf-app` example, so users can see how to configure how often Cloud Foundry runs the liveness check alongside the existing `health-check-*` parameters.

The new line is inserted directly after `health-check-timeout: 180 #seconds` in both descriptors, with a trailing comment explaining its purpose.

## Changes

- `cf-app/mta.yaml` — development descriptor: add `health-check-interval` next to the existing health-check parameters.
- `cf-app/mtad.yaml` — deployment descriptor: same addition for parity.

Two lines added in total; no other changes.

## Background

`health-check-interval` is an integer (seconds, optional) that controls how often Cloud Foundry runs the configured liveness check on an application instance. It became expressible through the MTA model after the underlying CF Java client adoption in the deploy service was refreshed; this example documents the canonical placement for end users.

## Acceptance criteria

Per the linked Jira: a user should be able to deploy the `cf-app` example with `health-check-interval` configured and observe the liveness probe running at the requested cadence. The example file alone covers the documentation half of that scenario.

## Relation to existing PR #115

This is an alternative to https://github.com/SAP-samples/cf-mta-examples/pull/115, which targets the same Jira key (LMCROSSITXSADEPLOY-3316) with a substantively similar change. Opened at the user's request so reviewers can compare both proposals and merge whichever is preferred; the other PR can then be closed.

JIRA: LMCROSSITXSADEPLOY-3316